### PR TITLE
Fix price per are display

### DIFF
--- a/src/components/OrderPanel/OrderPanel.js
+++ b/src/components/OrderPanel/OrderPanel.js
@@ -22,7 +22,7 @@ import {
   STOCK_INFINITE_MULTIPLE_ITEMS,
   LISTING_STATE_PUBLISHED,
 } from '../../util/types';
-import { formatMoney } from '../../util/currency';
+import { convertUnitToSubUnit, formatMoney, unitDivisor } from '../../util/currency';
 import { createSlug, parse, stringify } from '../../util/urlHelpers';
 import { userDisplayNameAsString } from '../../util/data';
 import {
@@ -531,7 +531,13 @@ const OrderPanel = props => {
         {priceperare && (
           <div className={css.availableFrom}>
             Price per are:{' '}
-            {formatMoneyIfSupportedCurrency(new Money(priceperare, marketplaceCurrency), intl)}
+            {formatMoneyIfSupportedCurrency(
+              new Money(
+                convertUnitToSubUnit(priceperare, unitDivisor(marketplaceCurrency)),
+                marketplaceCurrency
+              ),
+              intl
+            )}
           </div>
         )}
         {/* <div className={css.author}>


### PR DESCRIPTION
<img width="374" height="362" alt="Screenshot from 2025-07-29 11-22-25" src="https://github.com/user-attachments/assets/f1aae753-3573-49ed-8fc4-bfb529906df9" />


Trello card: https://trello.com/c/kCUuNYO7/20-feedback
Issue: The price_per_are is stored as regular text/number, need to be converted to money object

Changes:

- Adopt money object conversion from `FieldCurrencyInput` for price_per_are display