### PR TITLE
Adjust query for max price filter in rent

### DIFF
--- a/src/containers/SearchPage/SearchPage.duck.js
+++ b/src/containers/SearchPage/SearchPage.duck.js
@@ -169,6 +169,24 @@ export const searchListings = (searchParams, config) => (dispatch, getState, sdk
       : {};
   };
 
+  const rentPriceSearchParams = (weeklyPriceParam, monthlyPriceParam, yearlyPriceParam) => {
+    const formatPriceRange = priceParam => {
+      if (!priceParam) {
+        return null;
+      }
+      const splitted = priceParam.split(',');
+      const min = Number(splitted[0]);
+      const max = Number(splitted[1]) + 1;
+      return [min, max].join(',');
+    };
+
+    return {
+      pub_weekprice: formatPriceRange(weeklyPriceParam),
+      pub_monthprice: formatPriceRange(monthlyPriceParam),
+      pub_yearprice: formatPriceRange(yearlyPriceParam),
+    };
+  };
+
   const datesSearchParams = datesParam => {
     const searchTZ = 'Etc/UTC';
     const datesFilter = config.search.defaultFilters.find(f => f.key === 'dates');
@@ -250,6 +268,9 @@ export const searchListings = (searchParams, config) => (dispatch, getState, sdk
   const {
     perPage,
     price,
+    pub_weekprice,
+    pub_monthprice,
+    pub_yearprice,
     dates,
     seats,
     sort,
@@ -259,6 +280,7 @@ export const searchListings = (searchParams, config) => (dispatch, getState, sdk
     ...restOfParams
   } = searchParams;
   const priceMaybe = priceSearchParams(price);
+  const rentPriceMaybe = rentPriceSearchParams(pub_weekprice, pub_monthprice, pub_yearprice);
   const datesMaybe = datesSearchParams(dates);
   const stockMaybe = stockFilters(datesMaybe);
   const seatsMaybe = seatsSearchParams(seats, datesMaybe);
@@ -282,6 +304,7 @@ export const searchListings = (searchParams, config) => (dispatch, getState, sdk
       isListingTypeVariant
     ),
     ...priceMaybe,
+    ...rentPriceMaybe,
     ...datesMaybe,
     // ...stockMaybe,
     ...seatsMaybe,


### PR DESCRIPTION
<img width="452" height="332" alt="Screenshot from 2025-07-30 11-00-57" src="https://github.com/user-attachments/assets/1664e782-2936-4ddc-9fd9-7e6fef7a19da" />


### Issue: 
sharetribe will not include value equal to max in the query result

### Changes:

- Add value of one (1) to max rent price, similar to how it is done in the simple price. For example max=1,000,000 will become 1,000,001 in the query