### PR TITLE
Adjust map price label for rental

### DIFF
--- a/src/containers/SearchPage/SearchMap/SearchMapWithMapbox.js
+++ b/src/containers/SearchPage/SearchMap/SearchMapWithMapbox.js
@@ -402,6 +402,19 @@ class SearchMapWithMapbox extends Component {
 
     if (this.map) {
       // Create markers out of price labels and grouped labels
+
+      const queryParams = new URLSearchParams(this.props.location.search);
+      const isRentalParam = queryParams.get('pub_categoryLevel1') === 'rentalvillas';
+      const rentPeriodParam = queryParams.get('pub_weekprice')
+        ? 'weekprice'
+        : queryParams.get('pub_monthprice')
+        ? 'monthprice'
+        : queryParams.get('pub_yearprice')
+        ? 'yearprice'
+        : isRentalParam
+        ? 'noFilter'
+        : null;
+
       const labels = priceLabelsInLocations(
         listings,
         activeListingId,
@@ -428,6 +441,7 @@ class SearchMapWithMapbox extends Component {
           const existingMarkerId = this.currentMarkers.findIndex(
             marker => m.markerId === marker.markerId && marker.marker
           );
+          m.componentProps.rentPeriodParam = rentPeriodParam;
 
           if (existingMarkerId >= 0) {
             const { marker, markerContainer, ...rest } = this.currentMarkers[existingMarkerId];


### PR DESCRIPTION
<img width="379" height="412" alt="Screenshot from 2025-07-31 09-22-21" src="https://github.com/user-attachments/assets/6e1e7529-aee8-4600-996d-8e8fd1e88c83" />
<img width="383" height="429" alt="Screenshot from 2025-07-31 11-12-16" src="https://github.com/user-attachments/assets/7461b573-6833-461e-9158-b6ecabb93f8e" />


### Issue
Rentals don't have price. Instead they have rent prices in public data. The map needs to be updated to use them to display the price label

### Changes

- Read the filter param to determine the active rent filter (weekly, monthly or yearly)
- Use the public data price based on the active filter to display the price label on the map