### PR TITLE
Dev tian listing card rental

### DIFF
--- a/src/components/ListingCard/ListingCard.js
+++ b/src/components/ListingCard/ListingCard.js
@@ -142,7 +142,7 @@ export const checkPriceParams = () => {
 
 const PriceMaybe = props => {
   const { price, publicData, config, isRentals } = props;
-  const { listingType } = publicData || {};
+  const { listingType, weekprice, monthprice, yearprice } = publicData || {};
   const validListingTypes = config.listing.listingTypes;
   const foundListingTypeConfig = validListingTypes.find(conf => conf.listingType === listingType);
   const showPrice = displayPrice(foundListingTypeConfig);
@@ -150,9 +150,20 @@ const PriceMaybe = props => {
     return null;
   }
 
-  const formattedPrice = price ? formatPriceInMillions(price) : null;
-
   const priceParams = checkPriceParams();
+
+  let rentalPrice = price;
+  if (isRentals) {
+    if (priceParams?.yearprice) {
+      rentalPrice = yearprice;
+    } else if (priceParams?.monthprice) {
+      rentalPrice = monthprice;
+    } else if (priceParams?.weekprice) {
+      rentalPrice = weekprice;
+    } 
+  }
+
+  const formattedPrice = rentalPrice ? formatPriceInMillions(rentalPrice) : null;
 
   let suffix;
   if (priceParams?.weekprice || priceParams?.monthprice || priceParams?.yearprice) {
@@ -213,9 +224,6 @@ export const ListingCard = props => {
     categoryLevel1,
     landzone,
     landsize,
-    weekprice,
-    monthprice,
-    yearprice,
     Freehold,
   } = publicData;
   const tags = sortTags(pricee);
@@ -225,19 +233,7 @@ export const ListingCard = props => {
   const routeLocation = useLocation();
   const routes = useRouteConfiguration();
 
-  let price;
-
-  if (isRentals) {
-    if (pricee.includes('monthly')) {
-      price = monthprice;
-    } else if (pricee.includes('weekly')) {
-      price = weekprice;
-    } else if (pricee.includes('yearly')) {
-      price = yearprice;
-    }
-  } else {
-    price = p.amount / 100;
-  }
+  const price = isRentals ? null : p.amount / 100;
 
   const setActivePropsMaybe = setActiveListing
     ? {

--- a/src/containers/PageBuilder/SectionBuilder/SectionArticle/PropertyCards.js
+++ b/src/containers/PageBuilder/SectionBuilder/SectionArticle/PropertyCards.js
@@ -632,7 +632,7 @@ const PropertyCards = () => {
                         </span>
                         {isRentals && (
                           <span className={styles.priceUnit}>
-                            {weekprice ? '/ weekly' : monthprice ? '/ monthly' : '/ yearly'}
+                            {monthprice ? '/ monthly' : weekprice ? '/ weekly' : '/ yearly'}
                           </span>
                         )}
                       </div>


### PR DESCRIPTION
<img width="374" height="101" alt="Screenshot from 2025-08-05 20-20-39" src="https://github.com/user-attachments/assets/56871729-2977-4630-bce2-c0dd19165bc7" />

### Issue

- The default filter price in homepage is monthly, but the default label is weekly
- The displayed rental price on ListingCard does not take query filter into account

### Changes

- Change default labeling into monthly first
- Adjust logic for displayed ListingCard rental price