### PR TITLE
Fix overlay on location autocomplete mobile

### DIFF
--- a/src/components/LocationAutocompleteInput/LocationAutocompleteInputImpl.js
+++ b/src/components/LocationAutocompleteInput/LocationAutocompleteInputImpl.js
@@ -197,7 +197,7 @@ const LocationPredictionsList = React.forwardRef((props, ref) => {
 
   return (
     <div className={classes} ref={ref}>
-      <div className={css.closeDropdown} onClick={onCloseDropdown} />
+      {!isMobile && <div className={css.closeDropdown} onClick={onCloseDropdown} />}
       <ul className={css.predictions}>
         <li className={css.menuItemMobile}>
           <h2 className={css.menuItemMobileTitle}>


### PR DESCRIPTION
The onclose overlay is covering the location prediction list in mobile, so the event handler on the prediction list do not work

### Changes

- Disable the overlay on mobile