### PR TITLE
fix: short-circuit unmatched routes before SSR

### DIFF
--- a/server/dataLoader.js
+++ b/server/dataLoader.js
@@ -43,6 +43,13 @@ exports.loadData = function(requestUrl, sdk, appInfo) {
 
   const store = configureStore({}, sdk);
 
+  const pathnameWithoutLocale =
+    locale !== 'en' ? pathname.replace(`/${locale}`, '') || '/' : pathname;
+  const matchedDefaultRoutes = matchPathname(
+    pathnameWithoutLocale,
+    routeConfiguration(defaultConfig.layout)
+  );
+
   if (PREVENT_DATA_LOADING_IN_SSR) {
     return Promise.resolve({
       preloadedState: store.getState(),
@@ -51,10 +58,17 @@ exports.loadData = function(requestUrl, sdk, appInfo) {
     });
   }
 
+  if (matchedDefaultRoutes.length === 0) {
+    return Promise.resolve({
+      preloadedState: store.getState(),
+      translations,
+      hostedConfig: {},
+      unmatchedRoute: true,
+    });
+  }
+
   const dataLoadingCalls = hostedConfigAsset => {
     const config = mergeConfig(hostedConfigAsset, defaultConfig);
-    const pathnameWithoutLocale =
-      locale !== 'en' ? pathname.replace(`/${locale}`, '') || '/' : pathname;
     const matchedRoutes = matchPathname(pathnameWithoutLocale, routeConfiguration(config.layout));
     const calls = [store.dispatch(fetchConversionRate())];
     return matchedRoutes.reduce((calls, match) => {

--- a/server/dataLoader.test.js
+++ b/server/dataLoader.test.js
@@ -1,0 +1,54 @@
+process.env.REACT_APP_MARKETPLACE_ROOT_URL = 'https://balilistings.com';
+
+const { loadData } = require('./dataLoader');
+
+const createAppInfo = matchPathname => {
+  const dispatch = jest.fn(action =>
+    action && typeof action.then === 'function' ? action : Promise.resolve()
+  );
+  const store = {
+    dispatch,
+    getState: () => ({}),
+  };
+  const fetchAppAssets = jest.fn(() => Promise.resolve({}));
+
+  return {
+    appInfo: {
+      matchPathname,
+      configureStore: jest.fn(() => store),
+      routeConfiguration: jest.fn(() => []),
+      defaultConfig: {
+        layout: {},
+        appCdnAssets: {},
+      },
+      mergeConfig: jest.fn((hostedConfig, defaultConfig) => defaultConfig),
+      fetchAppAssets,
+    },
+    dispatch,
+    fetchAppAssets,
+  };
+};
+
+describe('server-side data loading', () => {
+  test('skips hosted asset loading for unmatched routes', async () => {
+    const matchPathname = jest.fn(() => []);
+    const { appInfo, dispatch, fetchAppAssets } = createAppInfo(matchPathname);
+
+    const result = await loadData('/missing-page', {}, appInfo);
+
+    expect(matchPathname).toHaveBeenCalledWith('/missing-page', []);
+    expect(dispatch).not.toHaveBeenCalled();
+    expect(fetchAppAssets).not.toHaveBeenCalled();
+    expect(result.unmatchedRoute).toBe(true);
+  });
+
+  test('keeps loading data for matched application routes', async () => {
+    const matchPathname = jest.fn(() => [{ route: {} }]);
+    const { appInfo, fetchAppAssets } = createAppInfo(matchPathname);
+
+    const result = await loadData('/', {}, appInfo);
+
+    expect(fetchAppAssets).toHaveBeenCalledWith({});
+    expect(result.unmatchedRoute).toBeUndefined();
+  });
+});

--- a/server/index.js
+++ b/server/index.js
@@ -240,13 +240,17 @@ const noCacheHeaders = {
   'Cache-control': 'no-cache, no-store, must-revalidate',
 };
 
+const notFoundCacheHeaders = {
+  'Cache-Control': 'public, max-age=60, s-maxage=60',
+};
+
 app.get('*', async (req, res) => {
   if (req.url.startsWith('/static/')) {
     // The express.static middleware only handles static resources
     // that it finds, otherwise passes them through. However, we don't
     // want to render the app for missing static resources and can
     // just return 404 right away.
-    return res.status(404).send('Static asset not found.');
+    return res.set(notFoundCacheHeaders).status(404).send('Static asset not found.');
   }
 
   if (req.url === '/_status.json') {
@@ -278,6 +282,12 @@ app.get('*', async (req, res) => {
   dataLoader
     .loadData(req.url, sdk, appInfo)
     .then(data => {
+      if (data.unmatchedRoute) {
+        res.set(notFoundCacheHeaders);
+        res.status(404).send(errorPage404);
+        return null;
+      }
+
       const { preloadedState, hostedConfig } = data;
       const locale = req.locale;
       let translations;
@@ -305,6 +315,10 @@ app.get('*', async (req, res) => {
       return renderer.render(req.url, context, updatedData, renderApp, webExtractor, cspNonce);
     })
     .then(html => {
+      if (html == null) {
+        return;
+      }
+
       if (dev) {
         const debugData = {
           url: req.url,
@@ -340,7 +354,7 @@ app.get('*', async (req, res) => {
       } else if (context.notfound) {
         // NotFoundPage component injects the context.notfound when a
         // 404 should be returned
-        res.set(noCacheHeaders);
+        res.set(notFoundCacheHeaders);
         res.status(404).send(html);
       } else {
         if (isLandingPage && PAGE_CACHE_DURATION > 0) {


### PR DESCRIPTION
## What changed

- Preflight requests against the existing default route configuration.
- Return a cacheable 404 before hosted asset loading, data loading, or React SSR for unmatched app routes.
- Return a cacheable 404 for missing static assets.
- Add focused regression coverage for unmatched and matched routes.

## Root cause

The server started hosted asset loading and SSR data work before it knew whether a URL matched an application route. Automated requests to missing pages therefore consumed origin resources and could trigger repeated configuration/API work.

## Validation

- Parsed the changed server files successfully.
- Exercised unmatched and matched data-loader behavior with mocked dependencies.
- Render build and live readback will be verified after merge.