### PR TITLE
fix: block inactive commercial search variants

### DIFF
--- a/server/dataLoader.js
+++ b/server/dataLoader.js
@@ -27,7 +27,7 @@ const isDisabledCommercialSearch = (pathname, search) => {
 
   const searchParams = new URLSearchParams(search);
   return [...searchParams.entries()].some(([key, value]) => {
-    const isCategoryParam = /^pub_categoryLevel\\d+$/i.test(key);
+    const isCategoryParam = /^pub_categoryLevel\d+$/i.test(key);
     const hasDisabledCategory = value
       .split(',')
       .some(category => DISABLED_COMMERCIAL_VALUES.has(category.trim().toLowerCase()));

--- a/server/dataLoader.js
+++ b/server/dataLoader.js
@@ -9,6 +9,32 @@ const { getSupportedLocales } = require('../src/util/translation');
 
 const PREVENT_DATA_LOADING_IN_SSR = process.env.PREVENT_DATA_LOADING_IN_SSR === 'true';
 
+const DISABLED_COMMERCIAL_VALUES = new Set(['commercial', 'commerical']);
+
+const isDisabledCommercialSearch = (pathname, search) => {
+  const pathSegments = pathname.split('/').filter(Boolean);
+  const isSearchRoute =
+    pathSegments[0]?.toLowerCase() === 's' && pathSegments.length <= 2;
+
+  if (!isSearchRoute) {
+    return false;
+  }
+
+  const listingTypePath = pathSegments.length === 2 ? pathSegments[1] : null;
+  if (listingTypePath && DISABLED_COMMERCIAL_VALUES.has(listingTypePath.toLowerCase())) {
+    return true;
+  }
+
+  const searchParams = new URLSearchParams(search);
+  return [...searchParams.entries()].some(([key, value]) => {
+    const isCategoryParam = /^pub_categoryLevel\\d+$/i.test(key);
+    const hasDisabledCategory = value
+      .split(',')
+      .some(category => DISABLED_COMMERCIAL_VALUES.has(category.trim().toLowerCase()));
+    return isCategoryParam && hasDisabledCategory;
+  });
+};
+
 const extractHostedConfig = configAssets => {
   const configEntries = Object.entries(configAssets);
   return configEntries.reduce((collectedData, [name, content]) => {
@@ -49,6 +75,15 @@ exports.loadData = function(requestUrl, sdk, appInfo) {
     pathnameWithoutLocale,
     routeConfiguration(defaultConfig.layout)
   );
+
+  if (isDisabledCommercialSearch(pathnameWithoutLocale, search)) {
+    return Promise.resolve({
+      preloadedState: store.getState(),
+      translations,
+      hostedConfig: {},
+      unmatchedRoute: true,
+    });
+  }
 
   if (PREVENT_DATA_LOADING_IN_SSR) {
     return Promise.resolve({

--- a/server/dataLoader.test.js
+++ b/server/dataLoader.test.js
@@ -51,4 +51,30 @@ describe('server-side data loading', () => {
     expect(fetchAppAssets).toHaveBeenCalledWith({});
     expect(result.unmatchedRoute).toBeUndefined();
   });
+  test.each([
+    '/s/commercial',
+    '/s/commerical',
+    '/s?pub_categoryLevel1=commercial',
+    '/s?pub_categoryLevel1=commerical',
+  ])('short-circuits inactive commercial search request %s', async requestUrl => {
+    const matchPathname = jest.fn(() => [{ route: {} }]);
+    const { appInfo, dispatch, fetchAppAssets } = createAppInfo(matchPathname);
+
+    const result = await loadData(requestUrl, {}, appInfo);
+
+    expect(dispatch).not.toHaveBeenCalled();
+    expect(fetchAppAssets).not.toHaveBeenCalled();
+    expect(result.unmatchedRoute).toBe(true);
+  });
+
+  test('keeps active category search routes working', async () => {
+    const matchPathname = jest.fn(() => [{ route: {} }]);
+    const { appInfo, fetchAppAssets } = createAppInfo(matchPathname);
+
+    const result = await loadData('/s?pub_categoryLevel1=rentalvillas', {}, appInfo);
+
+    expect(fetchAppAssets).toHaveBeenCalledWith({});
+    expect(result.unmatchedRoute).toBeUndefined();
+  });
+
 });


### PR DESCRIPTION
## What changed

- Return the existing cacheable 404 before hosted asset loading for the inactive `/s/commercial` and `/s/commerical` search variants.
- Block legacy `pub_categoryLevel*` query values for both spellings.
- Keep active search categories such as `rentalvillas` unchanged.
- Add regression coverage for all blocked variants and an active category route.

## Why

The public UI exposes Rentals, For Sale, and Land, but `/s/commercial` still matched the generic listing-type route and reached search loading. The old commercial category also appeared in the hosted configuration warning.

## Validation

- Server source and test files parse successfully.
- Focused mocked loader checks: all four inactive variants short-circuit with zero asset/API dispatches; active `rentalvillas` continues loading.